### PR TITLE
Add minimum node version

### DIFF
--- a/.changeset/cuddly-coins-worry.md
+++ b/.changeset/cuddly-coins-worry.md
@@ -1,0 +1,5 @@
+---
+"cf-speedtest": patch
+---
+
+Add minimum node version for this script to run

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,17 +2,21 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Requirements
+
+- Node.js 18 or higher
+
 ## Installation
 
 ```bash
 # Install globally from npm
-npm install -g cf-speedtest-cli
+npm install -g cf-speedtest
 
 # Or install globally using pnpm
-pnpm add -g cf-speedtest-cli
+pnpm add -g cf-speedtest
 
 # Or run directly with npx
-npx cf-speedtest-cli
+npx cf-speedtest
 ```
 
 ## Building and Running

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 A simple CLI tool to measure your Cloudflare network performance, including latency, packet loss, download, and upload
 speeds.
 
+## Requirements
+
+- Node.js 18 or higher
+
 ## Installation
 
 Install globally via npm:

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "typescript": "^5.8.3",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.1.4"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to specify that Node.js version 18 or higher is required.
  - Installation instructions now consistently reference the correct package name.
- **Chores**
  - Enforced a minimum Node.js version requirement (18+) for installing and running the package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->